### PR TITLE
v3 Additions / Fixes

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -370,8 +370,6 @@ class ShokoCommonAgent:
                 if not Prefs['SingleSeasonOrdering'] and len(ep_data['tvdb']) != 0:
                     ep_data['tvdb'] = ep_data['tvdb'][0] # Take the first link, as explained before
                     season = ep_data['tvdb']['Season']
-                    if season <= 0 and ep_type == 'Normal': season = 1
-                    elif season > 0 and ep_type == 'Special': season = 0
 
                 Log('Season: %s', season)
                 Log('Episode: %s', ep_data['anidb']['EpisodeNumber'])

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -394,9 +394,19 @@ class ShokoCommonAgent:
                     if title is not None: break
                 if title is None: title = ep_titles['en'] # If not found, fallback to EN title
 
-                # TvDB episode title fallback
+                # Replace Ambiguous Titles with Series Title
                 SingleEntryTitles = ['Complete Movie', 'Music Video', 'OAD', 'OVA', 'Short Movie', 'TV Special', 'Web'] # AniDB titles used for single entries which are ambiguous
-                if (title in SingleEntryTitles or title.startswith('Episode ')) and try_get(ep_data['tvdb'], 'Title') != '':
+                if title in SingleEntryTitles:
+                    # Make a dict of language -> title for all series titles in anidb data
+                    series_titles = {}
+                    for item in series_data['anidb']['Titles']:
+                        series_titles[item['Language']] = item['Name']
+                                   
+                    title = series_titles[lang.lower()] # Get series title according to the preference above
+                    if title is None: title = ep_titles['en'] # If not found, fallback to EN series title
+
+                # TvDB episode title fallback
+                if title.startswith('Episode ') and try_get(ep_data['tvdb'], 'Title') != '':
                     title = try_get(ep_data['tvdb'], 'Title')
 
                 episode_obj.title = title
@@ -435,7 +445,7 @@ class ShokoCommonAgent:
                     director = episode_obj.directors.new()
                     director.name = directors['Staff']['Name']
 
-            # Set custom negative season names
+            # Set custom negative season names (To be enabled if Plex fixes blocking issue)
             # for season_num in metadata.seasons:
             #    season_title = None
             #    if season_num == '-1': season_title = 'Themes'

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -436,15 +436,15 @@ class ShokoCommonAgent:
                     director.name = directors['Staff']['Name']
 
             # Set custom negative season names
-            for season_num in metadata.seasons:
-                season_title = None
-                if season_num == '-1': season_title = 'Themes'
-                elif season_num == '-2': season_title = 'Trailers'
-                elif season_num == '-3': season_title = 'Parodies'
-                elif season_num == '-4': season_title = 'Other'
-                if int(season_num) < 0 and season_title is not None:
-                    Log('Renaming season: %s to %s' % (season_num, season_title))
-                    metadata.seasons[season_num].title = season_title
+            # for season_num in metadata.seasons:
+            #    season_title = None
+            #    if season_num == '-1': season_title = 'Themes'
+            #    elif season_num == '-2': season_title = 'Trailers'
+            #    elif season_num == '-3': season_title = 'Parodies'
+            #    elif season_num == '-4': season_title = 'Other'
+            #    if int(season_num) < 0 and season_title is not None:
+            #        Log('Renaming season: %s to %s' % (season_num, season_title))
+            #        metadata.seasons[season_num].title = season_title
 
             #adapted from: https://github.com/plexinc-agents/PlexThemeMusic.bundle/blob/fb5c77a60c925dcfd60e75a945244e07ee009e7c/Contents/Code/__init__.py#L41-L45
             if Prefs["themeMusic"]:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -393,6 +393,12 @@ class ShokoCommonAgent:
                     title = ep_titles[lang.lower()]
                     if title is not None: break
                 if title is None: title = ep_titles['en'] # If not found, fallback to EN title
+
+                # TvDB episode title fallback
+                SingleEntryTitles = ['Complete Movie', 'Music Video', 'OAD', 'OVA', 'Short Movie', 'TV Special', 'Web'] # AniDB titles used for single entries which are ambiguous
+                if (title in SingleEntryTitles or title.startswith('Episode ')) and try_get(ep_data['tvdb'], 'Title') != '':
+                    title = try_get(ep_data['tvdb'], 'Title')
+
                 episode_obj.title = title
 
                 Log('Episode Title: %s', episode_obj.title)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -426,6 +426,17 @@ class ShokoCommonAgent:
                     director = episode_obj.directors.new()
                     director.name = directors['Staff']['Name']
 
+            # Set custom negative season names
+            for season_num in metadata.seasons:
+                season_title = None
+                if season_num == '-1': season_title = 'Themes'
+                elif season_num == '-2': season_title = 'Trailers'
+                elif season_num == '-3': season_title = 'Parodies'
+                elif season_num == '-4': season_title = 'Other'
+                if int(season_num) < 0 and season_title is not None:
+                    Log('Renaming season: %s to %s' % (season_num, season_title))
+                    metadata.seasons[season_num].title = season_title
+
             #adapted from: https://github.com/plexinc-agents/PlexThemeMusic.bundle/blob/fb5c77a60c925dcfd60e75a945244e07ee009e7c/Contents/Code/__init__.py#L41-L45
             if Prefs["themeMusic"]:
                 for tid in try_get(series_data['shoko']['IDs'],'TvDB', []):

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -333,7 +333,8 @@ class ShokoCommonAgent:
             meta_role.role = role['Character']['Name']
             Log('%s - %s' % (meta_role.role, meta_role.name))
             image = role['Staff']['Image']
-            meta_role.photo = 'http://{host}:{port}/api/v3/Image/{source}/{type}/{id}'.format(host=Prefs['Hostname'], port=Prefs['Port'], source=image['Source'], type=image['Type'], id=image['ID'])
+            if image:
+                meta_role.photo = 'http://{host}:{port}/api/v3/Image/{source}/{type}/{id}'.format(host=Prefs['Hostname'], port=Prefs['Port'], source=image['Source'], type=image['Type'], id=image['ID'])
 
         # Get studio
         studio = HttpReq('api/v3/Series/%s/Cast?roleType=Studio' % aid) # http://127.0.0.1:8111/api/v3/Series/24/Cast?roleType=Studio

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -361,6 +361,7 @@ class ShokoCommonAgent:
 
                 # Get season number
                 season = 0
+                episode_number = None
                 if ep_type == 'Normal': season = 1
                 elif ep_type == 'Special': season = 0
                 elif ep_type == 'ThemeSong': season = -1
@@ -370,11 +371,15 @@ class ShokoCommonAgent:
                 if not Prefs['SingleSeasonOrdering'] and len(ep_data['tvdb']) != 0:
                     ep_data['tvdb'] = ep_data['tvdb'][0] # Take the first link, as explained before
                     season = ep_data['tvdb']['Season']
+                    episode_number = ep_data['tvdb']['Number']
+
+                if episode_number is None:
+                    episode_number = ep_data['anidb']['EpisodeNumber']
 
                 Log('Season: %s', season)
-                Log('Episode: %s', ep_data['anidb']['EpisodeNumber'])
+                Log('Episode: %s', episode_number)
 
-                episode_obj = metadata.seasons[season].episodes[ep_data['anidb']['EpisodeNumber']]
+                episode_obj = metadata.seasons[season].episodes[episode_number]
 
                 # Make a dict of language -> title for all titles in anidb data
                 ep_titles = {}

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -174,7 +174,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
 
                 Log.info('Season: %s', season)
 
-                if ep_data['tvdb'] is not None:
+                if ep_data['tvdb'] is not None and not Prefs['SingleSeasonOrdering']:
                     episode_number = ep_data['tvdb']['Number']
                 else:
                     episode_number = ep_data['anidb']['EpisodeNumber']

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -10,8 +10,7 @@ Prefs = {
     'Password': '',
     'IncludeSpecials': True,
     'IncludeOther': False,
-    'SingleSeasonOrdering': False,
-    'CombineSeriesAndMovies': False
+    'SingleSeasonOrdering': False
 }
 
 API_KEY = ''
@@ -169,7 +168,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 if season < 0 and Prefs['IncludeOther'] == False: continue
 
                 # Ignore movies in preference for Shoko Movie Scanner, but keep specials as Plex sees specials as duplicate
-                if (try_get(series_data['anidb'], 'Type', 'Unknown') == 'Movie' and season >= 1 and Prefs['CombineSeriesAndMovies'] == False):
+                if (try_get(series_data['anidb'], 'Type', 'Unknown') == 'Movie' and season >= 1):
                     Log.info('It\'s a movie. Skipping!')
                     continue
 

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -174,7 +174,11 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
 
                 Log.info('Season: %s', season)
 
-                episode_number = ep_data['anidb']['EpisodeNumber']
+                if ep_data['tvdb'] is not None:
+                    episode_number = ep_data['tvdb']['Number']
+                else:
+                    episode_number = ep_data['anidb']['EpisodeNumber']
+
                 Log.info('Episode Number: %s', episode_number)
 
                 vid = Media.Episode(show_title, season, episode_number)

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -155,6 +155,8 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 elif ep_type == 'Special': season = 0
                 elif ep_type == 'ThemeSong': season = -1
                 elif ep_type == 'Trailer': season = -2
+                elif ep_type == 'Parody': season = -3
+                elif ep_type == 'Unknown': season = -4
                 if not Prefs['SingleSeasonOrdering']:
                     ep_data['tvdb'] = HttpReq('api/v3/Episode/%s/TvDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/TvDB
                     ep_data['tvdb'] = try_get(ep_data['tvdb'], 0, None) # Take the first link, as explained before

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -162,8 +162,6 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                     ep_data['tvdb'] = try_get(ep_data['tvdb'], 0, None) # Take the first link, as explained before
                     if ep_data['tvdb'] is not None:
                         season = ep_data['tvdb']['Season']
-                        if season <= 0 and ep_type == 'Normal': season = 1
-                        elif season > 0 and ep_type == 'Special': season = 0
 
                 # Ignore these by choice.
                 if season == 0 and Prefs['IncludeSpecials'] == False: continue


### PR DESCRIPTION
This pr mostly fixes issues with files overlapping in certain situations while allowing seasons to be merged together into a single entry. There are also a few small bug fixes and TvDB fallback for various metadata.

- Fixes 'Other' and 'Parody' files overlapping with specials.
- Found a couple more airdates that had the potential to cause errors/crash the agent.
- Added fallback for missing AniDB episode descriptions from the TvDB.
- Allows parody and other files to fetch episode data as that was disabled completely.
- Fixed an issue where the agent would crash when null was returned for a character/cast image.
- ~~Added custom names for negative seasons (metadata xml only).~~
- Fix seasons overlapping when merging seasons of shows with mostly specials.
- Add TvDB episode number support for shows that are matched in shoko.
- Fix episode numbers when merging seasons that are split on TvDB but a single entry on AniDB.
- Fallback for missing or ambiguous AniDB titles.
- A scanner option to combine movies and tv shows.